### PR TITLE
Delete CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default owners: Nils and Tim
-*  @nh13 @tfenne


### PR DESCRIPTION
Having a default CODEOWNERS file has caused a lot more problems that it has benefits.  We're going to get rid of this in preference of establishing files in all the necessary repos.